### PR TITLE
add inline icon converter

### DIFF
--- a/antora-playbook-en.yml
+++ b/antora-playbook-en.yml
@@ -4,40 +4,16 @@ site:
   url: https://developers.plentymarkets.com/en-gb
 content:
   sources:
-  - url: https://github.com/plentymarkets/plenty-developers-docs
-    branches: main
+  - url: ./
+    branches: HEAD
     start_path: docs/en-gb
-  - url: https://github.com/plentymarkets/module-version-doc.git
-    branches:
-      - beta7
-      - early
-      - stable7
-  - url: https://github.com/plentymarkets/docs-raw
-    branches:
-      - beta7
-      - early
-      - stable7
-  - url: https://github.com/plentymarkets/api-doc
-    branches:
-      - master
-    start_path: plentymarkets/docs
-  - url: https://github.com/plentymarkets/api-doc
-    branches:
-      - master
-    start_path: plentyBase/docs
-  - url: https://github.com/plentymarkets/Ceres_docs-raw
-    branches:
-      - 4.*
-      - 5.*
-  - url: https://github.com/plentymarkets/IO_docs-raw
-    branches:
-      - 4.*
-      - 5.*
 asciidoc:
   attributes:
     tabs: tabs
+    icon: icon
   extensions:
   - ./lib/tabs-block.js
+  - ./lib/inline-icon.js
 output:
     dir: ./build/en-gb
 ui:

--- a/lib/inline-icon.js
+++ b/lib/inline-icon.js
@@ -1,0 +1,35 @@
+function inlineIcon () {
+    this.process((parent, target, attrs) => {
+
+        const icon = target;
+
+        let iconColour = '';
+        let iconSet = 'fa fa-';
+
+        if (attrs.set !== 'undefined') {
+            if (attrs.set === 'plenty') {
+                iconSet = 'psicon-';
+            }
+    
+            else if (attrs.set === 'material') {
+                iconSet = 'material-';
+            }                
+        }
+
+        if (typeof attrs.role !== 'undefined' && attrs.role) {
+            iconColour = ' ' + attrs.role;
+        }
+
+        text = `<span class = 'icon${iconColour}'><i class = ${iconSet}${icon}'</i></span>`;
+
+        // inlineNode = this.createInline(parent, 'image', null, { 'target': 'text' }).convert();
+
+        return text;
+    })
+}
+
+function register (registry) {
+    registry.inlineMacro('icon', inlineIcon)
+}
+
+module.exports.register = register


### PR DESCRIPTION
Adds a converter for inline icons. The converter supports Terra icons, Material icons and Font Awesome icons. Before the icons are actually displayed, the corresponding images need to be added to the UI repository.

Also, this implementation isn't as clean as it could be. As indicated in the commented line, [it should be possible](https://docs.asciidoctor.org/asciidoctor.js/latest/extend/extensions/inline-macro-processor/) to create a new node instead of simply returning a string. If anyone has a suggestion for how to implement this properly, please comment.